### PR TITLE
Fix color extension

### DIFF
--- a/Sources/SkeletonUI/Appearance/AppearanceInteractor.swift
+++ b/Sources/SkeletonUI/Appearance/AppearanceInteractor.swift
@@ -7,7 +7,7 @@ public enum GradientType: Equatable {
     case radial
 }
 
-extension Color {
+public struct SkeletonColor {
     public static var primary: Color {
         #if os(iOS)
             return Color(.systemGray4)
@@ -33,9 +33,10 @@ extension Color {
     }
 }
 
+
 public enum AppearanceType: Equatable {
-    case solid(color: Color = .primary, background: Color = .background)
-    case gradient(GradientType = .linear, color: Color = .primary, background: Color = .background, radius: CGFloat = 1, angle: CGFloat = .zero)
+    case solid(color: Color = SkeletonColor.primary, background: Color = SkeletonColor.background)
+    case gradient(GradientType = .linear, color: Color = SkeletonColor.primary, background: Color = SkeletonColor.background, radius: CGFloat = 1, angle: CGFloat = .zero)
 }
 
 // sourcery: AutoMockable


### PR DESCRIPTION
### Issue Link :link:
#18 **.primary color extension**

### Goals :soccer:
As the related issue mentions, the current implementation clashes with the built-in Color, so the goal of this PR is to address that.

### Implementation Details :construction:
For what I can tell, the current usage is simple enough to warrant a simple `struct` instead of an extension, as one should be wary of extending core functionality inside a library.

### Testing Details :mag:
No tests were added or removed in this PR.
