### PR TITLE
Add padding to multiline modifier

### DIFF
--- a/Examples/SkeletonUI-macOS-iOS/SkeletonUI-macOS-iOS/Views/CharacterView.swift
+++ b/Examples/SkeletonUI-macOS-iOS/SkeletonUI-macOS-iOS/Views/CharacterView.swift
@@ -25,7 +25,7 @@ struct CharacterView: View {
             Text(character?.name)
                 .skeleton(with: loading)
                 .shape(type: .capsule)
-                .multiline(lines: 3, scales: [1: 0.5, 2: 0.25])
+                .multiline(lines: 3, scales: [1: 0.5, 2: 0.25], padding: EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0))
                 .appearance(type: .gradient())
                 .animation(type: .linear())
         }
@@ -35,7 +35,7 @@ struct CharacterView: View {
 #if DEBUG
     struct CharacterView_Previews: PreviewProvider {
         static var previews: some View {
-            CharacterView(character: nil, loading: false)
+            CharacterView(character: nil, loading: true).previewLayout(.sizeThatFits).frame(width: 300, height: 100, alignment: .center)
         }
     }
 #endif

--- a/Examples/SkeletonUI-watchOS/SkeletonUI-watchOS.xcodeproj/xcshareddata/xcschemes/SkeletonUI-watchOS.xcscheme
+++ b/Examples/SkeletonUI-watchOS/SkeletonUI-watchOS.xcodeproj/xcshareddata/xcschemes/SkeletonUI-watchOS.xcscheme
@@ -54,10 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/SkeletonUI-watchOS WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "87A5D90D230803F50096BD32"
@@ -65,7 +63,7 @@
             BlueprintName = "SkeletonUI-watchOS WatchKit App"
             ReferencedContainer = "container:SkeletonUI-watchOS.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,10 +71,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/SkeletonUI-watchOS WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "87A5D90D230803F50096BD32"
@@ -84,16 +80,7 @@
             BlueprintName = "SkeletonUI-watchOS WatchKit App"
             ReferencedContainer = "container:SkeletonUI-watchOS.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "87A5D90D230803F50096BD32"
-            BuildableName = "SkeletonUI-watchOS WatchKit App.app"
-            BlueprintName = "SkeletonUI-watchOS WatchKit App"
-            ReferencedContainer = "container:SkeletonUI-watchOS.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing",
         "state": {
           "branch": null,
-          "revision": "12c6a7ce9d67f39a23c6bab757bdb073bd997885",
-          "version": "1.7.1"
+          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
+          "version": "1.9.0"
         }
       }
     ]

--- a/SkeletonUI.podspec
+++ b/SkeletonUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SkeletonUI'
-  s.version          = '1.0.5'
+  s.version          = '1.0.6'
   s.summary          = 'Elegant skeleton loading animation in SwiftUI and Combine'
   s.description      = <<-DESC
 SkeletonUI aims to bring an elegant, declarative syntax to skeleton loading animations. Get rid of loading screens or spinners and start using skeletons to represent final content shapes

--- a/Sources/SkeletonUI/Extensions/ModifiedContent+SkeletonModifier.swift
+++ b/Sources/SkeletonUI/Extensions/ModifiedContent+SkeletonModifier.swift
@@ -12,10 +12,11 @@ public extension ModifiedContent where Content: View, Modifier == SkeletonModifi
         return self
     }
 
-    func multiline(lines: Int, scales: [Int: CGFloat]? = nil, spacing: CGFloat? = nil) -> ModifiedContent<Content, SkeletonModifier> {
+    func multiline(lines: Int, scales: [Int: CGFloat]? = nil, spacing: CGFloat? = nil, padding: EdgeInsets? = nil) -> ModifiedContent<Content, SkeletonModifier> {
         modifier.skeleton.multiline.lines.send(lines)
         modifier.skeleton.multiline.scales.send(scales)
         modifier.skeleton.multiline.spacing.send(spacing)
+        modifier.skeleton.multiline.padding.send(padding)
         return self
     }
 

--- a/Sources/SkeletonUI/Modifiers/SkeletonModifier.swift
+++ b/Sources/SkeletonUI/Modifiers/SkeletonModifier.swift
@@ -31,6 +31,7 @@ public struct SkeletonModifier: ViewModifier {
                         }
                     }
                 }
+                .padding(skeleton.multiline.presenter.padding ?? EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                 .transition(skeleton.presenter.transition)
             } else {
                 content

--- a/Sources/SkeletonUI/Multiline/MultilineInteractor.swift
+++ b/Sources/SkeletonUI/Multiline/MultilineInteractor.swift
@@ -9,6 +9,7 @@ protocol MultilineInteractable: AnyObject {
     var scale: CurrentValueSubject<CGFloat, Never> { get }
     var spacing: CurrentValueSubject<CGFloat?, Never> { get }
     var scales: CurrentValueSubject<[Int: CGFloat]?, Never> { get }
+    var padding: CurrentValueSubject<EdgeInsets?, Never> { get }
 }
 
 final class MultilineInteractor: MultilineInteractable {
@@ -18,6 +19,7 @@ final class MultilineInteractor: MultilineInteractable {
     let scale: CurrentValueSubject<CGFloat, Never>
     let spacing: CurrentValueSubject<CGFloat?, Never>
     let scales: CurrentValueSubject<[Int: CGFloat]?, Never>
+    let padding: CurrentValueSubject<EdgeInsets?, Never>
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -27,6 +29,8 @@ final class MultilineInteractor: MultilineInteractable {
         scale = CurrentValueSubject<CGFloat, Never>(presenter.scale)
         spacing = CurrentValueSubject<CGFloat?, Never>(presenter.spacing)
         scales = CurrentValueSubject<[Int: CGFloat]?, Never>(presenter.scales)
+        padding = CurrentValueSubject<EdgeInsets?, Never>(presenter.padding)
+
         line.map { [weak self] line in
             guard let self = self else { fatalError() }
             if let scale = self.scales.value?[line] {
@@ -37,5 +41,6 @@ final class MultilineInteractor: MultilineInteractable {
         lines.assign(to: \.lines, on: presenter).store(in: &cancellables)
         scales.assign(to: \.scales, on: presenter).store(in: &cancellables)
         spacing.assign(to: \.spacing, on: presenter).store(in: &cancellables)
+        padding.assign(to: \.padding, on: presenter).store(in: &cancellables)
     }
 }

--- a/Sources/SkeletonUI/Multiline/MultilinePresenter.swift
+++ b/Sources/SkeletonUI/Multiline/MultilinePresenter.swift
@@ -6,4 +6,5 @@ final class MultilinePresenter: ObservableObject {
     @Published var spacing: CGFloat?
     @Published var scale: CGFloat = 1
     @Published var scales: [Int: CGFloat]?
+    @Published var padding: EdgeInsets?
 }

--- a/Tests/SkeletonUISnapshotTests/AutoMockable.generated.swift
+++ b/Tests/SkeletonUISnapshotTests/AutoMockable.generated.swift
@@ -93,6 +93,12 @@ class AppearanceInteractableMock: AppearanceInteractable {
 
 }
 class MultilineInteractableMock: MultilineInteractable {
+    var underlyingPadding: CurrentValueSubject<EdgeInsets?, Never>!
+    var padding: CurrentValueSubject<EdgeInsets?, Never> {
+        get { return underlyingPadding }
+        set(value) { underlyingPadding = value }
+    }
+    
     var presenter: MultilinePresenter {
         get { return underlyingPresenter }
         set(value) { underlyingPresenter = value }

--- a/Tests/SkeletonUISnapshotTests/SnapshotTests.swift
+++ b/Tests/SkeletonUISnapshotTests/SnapshotTests.swift
@@ -22,6 +22,11 @@ final class SnapshotTests: XCTestCase {
         let view = Text(nil).skeleton(with: true).appearance(type: .solid()).shape(type: .rectangle).multiline(lines: 2, scales: [1: 0.5]).animation(type: .pulse())
         assertNamedSnapshot(matching: view, as: .image(size: CGSize(width: 100, height: 50)))
     }
+    
+    func testCustomTextWithPadding() {
+        let view = Text(nil).skeleton(with: true).appearance(type: .solid()).shape(type: .rectangle).multiline(lines: 2, scales: [1: 0.5], padding: EdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0)).animation(type: .pulse())
+        assertNamedSnapshot(matching: view, as: .image(size: CGSize(width: 100, height: 60)))
+    }
 
     func testDefaultImage() {
         #if os(macOS)


### PR DESCRIPTION
### Goals :soccer:
SkeletonUI uses GeometryReader to read the views size. GeometryReader is greedy and tacks all the size it gets.
If I have a typical Layout like:
`HStack {
Text("a")
VStack { 
Text("a")
Text("a")
}.skeleton(true).multiline(...)
}`

This causes VStack to take the complete height of the container. Also the multiline is "blown" up. You can work around by applying extra constraints when the skeleton is there, but that increases the complexity of the layout a lout.

A simple solution is to add a padding option to the multiline modifier, this enables more flexibility when adding the skeleton.

### Testing Details :mag:
Added a new snapshot test`testCustomTextWithPadding`