### PR TITLE
Add checks for code so it can be used in projects with a minimum target < iOS 13

### DIFF
--- a/Sources/SkeletonUI/Angle/AngleInteractor.swift
+++ b/Sources/SkeletonUI/Angle/AngleInteractor.swift
@@ -1,7 +1,9 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
-// sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol AngleInteractable: AnyObject {
     var presenter: AnglePresenter { get }
     var animation: CurrentValueSubject<Animation?, Never> { get }
@@ -9,6 +11,7 @@ protocol AngleInteractable: AnyObject {
     var range: CurrentValueSubject<ClosedRange<Double>, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class AngleInteractor: AngleInteractable {
     let presenter = AnglePresenter()
     let animation: CurrentValueSubject<Animation?, Never>
@@ -27,3 +30,5 @@ final class AngleInteractor: AngleInteractable {
         range.map { $0.lowerBound }.assign(to: \.value, on: presenter).store(in: &cancellables)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Angle/AnglePresenter.swift
+++ b/Sources/SkeletonUI/Angle/AnglePresenter.swift
@@ -1,7 +1,12 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class AnglePresenter: ObservableObject {
     @Published var animation: Animation?
     @Published var value: Double = .zero
     @Published var range: ClosedRange<Double> = .zero ... 360
 }
+
+#endif

--- a/Sources/SkeletonUI/Animation/AnimationInteractor.swift
+++ b/Sources/SkeletonUI/Animation/AnimationInteractor.swift
@@ -1,6 +1,9 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum AnimationType: Equatable {
     case none
     case pulse(range: ClosedRange<Double> = .zero ... 1, duration: Double = 2, delay: Double = 1, speed: Double = 2, autoreverses: Bool = true)
@@ -8,6 +11,7 @@ public enum AnimationType: Equatable {
 }
 
 // sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol AnimationInteractable: AnyObject {
     var position: PositionInteractable { get }
     var opacity: OpacityInteractable { get }
@@ -16,6 +20,7 @@ protocol AnimationInteractable: AnyObject {
     var type: CurrentValueSubject<AnimationType, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class AnimationInteractor: AnimationInteractable {
     let position: PositionInteractable
     let opacity: OpacityInteractable
@@ -54,3 +59,5 @@ final class AnimationInteractor: AnimationInteractable {
         }.store(in: &cancellables)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Appearance/AppearanceInteractor.swift
+++ b/Sources/SkeletonUI/Appearance/AppearanceInteractor.swift
@@ -1,12 +1,16 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum GradientType: Equatable {
     case linear
     case angular
     case radial
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct SkeletonColor {
     public static var primary: Color {
         #if os(iOS)
@@ -33,18 +37,20 @@ public struct SkeletonColor {
     }
 }
 
-
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum AppearanceType: Equatable {
     case solid(color: Color = SkeletonColor.primary, background: Color = SkeletonColor.background)
     case gradient(GradientType = .linear, color: Color = SkeletonColor.primary, background: Color = SkeletonColor.background, radius: CGFloat = 1, angle: CGFloat = .zero)
 }
 
 // sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol AppearanceInteractable: AnyObject {
     var presenter: AppearancePresenter { get }
     var type: CurrentValueSubject<AppearanceType, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class AppearanceInteractor: AppearanceInteractable {
     let presenter = AppearancePresenter()
     let type: CurrentValueSubject<AppearanceType, Never>
@@ -56,3 +62,5 @@ final class AppearanceInteractor: AppearanceInteractable {
         type.assign(to: \.type, on: presenter).store(in: &cancellables)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Appearance/AppearancePresenter.swift
+++ b/Sources/SkeletonUI/Appearance/AppearancePresenter.swift
@@ -1,5 +1,10 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class AppearancePresenter: ObservableObject {
     @Published var type: AppearanceType = .gradient()
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/ClosedRange+Normalize.swift
+++ b/Sources/SkeletonUI/Extensions/ClosedRange+Normalize.swift
@@ -1,5 +1,6 @@
-import CoreGraphics
+#if arch(x86_64) || arch(arm64)
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension ClosedRange where Bound == CGFloat {
     func normalize(with range: ClosedRange) -> ClosedRange {
         let lowerBound = range.lowerBound == .zero ? self.lowerBound : range.lowerBound
@@ -8,9 +9,12 @@ extension ClosedRange where Bound == CGFloat {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension ClosedRange where Bound == Double {
     func normalize(with range: ClosedRange<CGFloat>) -> ClosedRange {
         let normalized = (CGFloat(lowerBound) ... CGFloat(upperBound)).normalize(with: range)
         return Double(normalized.lowerBound) ... Double(normalized.upperBound)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/Image+OptionalType.swift
+++ b/Sources/SkeletonUI/Extensions/Image+OptionalType.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension Image {
     #if os(iOS) || os(tvOS) || os(watchOS)
         init(uiImage: UIImage?) {
@@ -100,3 +103,5 @@ public extension Image {
         }
     #endif
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/ModifiedContent+SkeletonModifier.swift
+++ b/Sources/SkeletonUI/Extensions/ModifiedContent+SkeletonModifier.swift
@@ -1,3 +1,5 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -24,3 +26,5 @@ public extension ModifiedContent where Content: View, Modifier == SkeletonModifi
         return self
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/Optional+OptionalType.swift
+++ b/Sources/SkeletonUI/Extensions/Optional+OptionalType.swift
@@ -1,5 +1,10 @@
+#if arch(x86_64) || arch(arm64)
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension Optional: OptionalType {
     public var wrapped: Wrapped? {
         self
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/SecureField+OptionalType.swift
+++ b/Sources/SkeletonUI/Extensions/SecureField+OptionalType.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension SecureField where Label == Text {
     init(_ titleKey: LocalizedStringKey?, text: Binding<String>, onCommit: @escaping () -> Void = {}) {
         if let titleKey = titleKey {
@@ -17,3 +20,5 @@ public extension SecureField where Label == Text {
         }
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/Text+OptionalType.swift
+++ b/Sources/SkeletonUI/Extensions/Text+OptionalType.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension Text {
     init<S>(_ content: S?) where S: OptionalType, S.Wrapped: StringProtocol {
         if let content = content?.wrapped {
@@ -25,3 +28,5 @@ public extension Text {
         }
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/TextField+OptionalType.swift
+++ b/Sources/SkeletonUI/Extensions/TextField+OptionalType.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension TextField where Label == Text {
     init(titleKey: LocalizedStringKey?, text: Binding<String>, onEditingChanged: @escaping (Bool) -> Void = { _ in }, onCommit: @escaping () -> Void = {}) {
         if let titleKey = titleKey {
@@ -33,3 +36,5 @@ public extension TextField where Label == Text {
         }
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/Toggle+OptionalType.swift
+++ b/Sources/SkeletonUI/Extensions/Toggle+OptionalType.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension Toggle where Label: View {
     init(isOn: Binding<Bool>?, @ViewBuilder label: () -> Label) {
         if let isOn = isOn {
@@ -10,6 +13,7 @@ public extension Toggle where Label: View {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension Toggle where Label == Text {
     init(_ titleKey: LocalizedStringKey?, isOn: Binding<Bool>) {
         if let titleKey = titleKey {
@@ -27,3 +31,5 @@ public extension Toggle where Label == Text {
         }
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/UnitPoint+Angle.swift
+++ b/Sources/SkeletonUI/Extensions/UnitPoint+Angle.swift
@@ -1,8 +1,13 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension UnitPoint {
     static func point(with position: CGFloat, _ radius: CGFloat, _ angle: CGFloat) -> UnitPoint {
         let radians = angle * .pi / 180.0
         return UnitPoint(x: (position + radius) * cos(radians), y: (position + radius) * sin(radians))
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Extensions/View+SkeletonModifier.swift
+++ b/Sources/SkeletonUI/Extensions/View+SkeletonModifier.swift
@@ -1,3 +1,5 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -6,3 +8,5 @@ public extension View {
         modifier(SkeletonModifier(skeleton: SkeletonInteractor(loading, size: size, transition: transition, animated: animated)))
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Modifiers/SkeletonModifier.swift
+++ b/Sources/SkeletonUI/Modifiers/SkeletonModifier.swift
@@ -1,3 +1,5 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -41,3 +43,5 @@ public struct SkeletonModifier: ViewModifier {
         .animation(skeleton.presenter.animated, value: skeleton.presenter.loading)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Multiline/MultilineInteractor.swift
+++ b/Sources/SkeletonUI/Multiline/MultilineInteractor.swift
@@ -1,7 +1,10 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
 // sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol MultilineInteractable: AnyObject {
     var presenter: MultilinePresenter { get }
     var line: CurrentValueSubject<Int, Never> { get }
@@ -11,6 +14,7 @@ protocol MultilineInteractable: AnyObject {
     var scales: CurrentValueSubject<[Int: CGFloat]?, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class MultilineInteractor: MultilineInteractable {
     let presenter = MultilinePresenter()
     let line: CurrentValueSubject<Int, Never>
@@ -39,3 +43,5 @@ final class MultilineInteractor: MultilineInteractable {
         spacing.assign(to: \.spacing, on: presenter).store(in: &cancellables)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Multiline/MultilinePresenter.swift
+++ b/Sources/SkeletonUI/Multiline/MultilinePresenter.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class MultilinePresenter: ObservableObject {
     @Published var line: Int = 0
     @Published var lines: Int = 1
@@ -7,3 +10,5 @@ final class MultilinePresenter: ObservableObject {
     @Published var scale: CGFloat = 1
     @Published var scales: [Int: CGFloat]?
 }
+
+#endif

--- a/Sources/SkeletonUI/Opacity/OpacityInteractor.swift
+++ b/Sources/SkeletonUI/Opacity/OpacityInteractor.swift
@@ -1,7 +1,10 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
 // sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol OpacityInteractable: AnyObject {
     var presenter: OpacityPresenter { get }
     var animation: CurrentValueSubject<Animation?, Never> { get }
@@ -9,6 +12,7 @@ protocol OpacityInteractable: AnyObject {
     var range: CurrentValueSubject<ClosedRange<Double>, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class OpacityInteractor: OpacityInteractable {
     let presenter = OpacityPresenter()
     let animation: CurrentValueSubject<Animation?, Never>
@@ -27,3 +31,5 @@ final class OpacityInteractor: OpacityInteractable {
         range.map { $0.lowerBound }.assign(to: \.value, on: presenter).store(in: &cancellables)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Opacity/OpacityPresenter.swift
+++ b/Sources/SkeletonUI/Opacity/OpacityPresenter.swift
@@ -1,7 +1,12 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class OpacityPresenter: ObservableObject {
     @Published var animation: Animation?
     @Published var value: Double = .zero
     @Published var range: ClosedRange<Double> = .zero ... 1
 }
+
+#endif

--- a/Sources/SkeletonUI/Position/PositionInteractor.swift
+++ b/Sources/SkeletonUI/Position/PositionInteractor.swift
@@ -1,7 +1,10 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
 // sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol PositionInteractable: AnyObject {
     var presenter: PositionPresenter { get }
     var animation: CurrentValueSubject<Animation?, Never> { get }
@@ -9,6 +12,7 @@ protocol PositionInteractable: AnyObject {
     var range: CurrentValueSubject<ClosedRange<CGFloat>, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class PositionInteractor: PositionInteractable {
     let presenter = PositionPresenter()
     let animation: CurrentValueSubject<Animation?, Never>
@@ -27,3 +31,5 @@ final class PositionInteractor: PositionInteractable {
         range.map { $0.lowerBound }.assign(to: \.value, on: presenter).store(in: &cancellables)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Position/PositionPresenter.swift
+++ b/Sources/SkeletonUI/Position/PositionPresenter.swift
@@ -1,7 +1,12 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class PositionPresenter: ObservableObject {
     @Published var animation: Animation?
     @Published var value: CGFloat = .zero
     @Published var range: ClosedRange<CGFloat> = .zero ... 1
 }
+
+#endif

--- a/Sources/SkeletonUI/Protocols/OptionalType.swift
+++ b/Sources/SkeletonUI/Protocols/OptionalType.swift
@@ -1,4 +1,9 @@
+#if arch(x86_64) || arch(arm64)
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public protocol OptionalType {
     associatedtype Wrapped
     var wrapped: Wrapped? { get }
 }
+
+#endif

--- a/Sources/SkeletonUI/Radius/RadiusInteractor.swift
+++ b/Sources/SkeletonUI/Radius/RadiusInteractor.swift
@@ -1,7 +1,10 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
 // sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol RadiusInteractable: AnyObject {
     var presenter: RadiusPresenter { get }
     var animation: CurrentValueSubject<Animation?, Never> { get }
@@ -9,6 +12,7 @@ protocol RadiusInteractable: AnyObject {
     var range: CurrentValueSubject<ClosedRange<CGFloat>, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class RadiusInteractor: RadiusInteractable {
     let presenter = RadiusPresenter()
     let animation: CurrentValueSubject<Animation?, Never>
@@ -27,3 +31,4 @@ final class RadiusInteractor: RadiusInteractable {
         range.map { $0.lowerBound }.assign(to: \.value, on: presenter).store(in: &cancellables)
     }
 }
+#endif

--- a/Sources/SkeletonUI/Radius/RadiusPresenter.swift
+++ b/Sources/SkeletonUI/Radius/RadiusPresenter.swift
@@ -1,7 +1,12 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class RadiusPresenter: ObservableObject {
     @Published var animation: Animation?
     @Published var value: CGFloat = .zero
     @Published var range: ClosedRange<CGFloat> = 1 ... 40
 }
+
+#endif

--- a/Sources/SkeletonUI/Shape/ShapeInteractor.swift
+++ b/Sources/SkeletonUI/Shape/ShapeInteractor.swift
@@ -1,11 +1,14 @@
-import Combine
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum RoundedType: Equatable {
     case radius(CGFloat, style: RoundedCornerStyle = .continuous)
     case size(CGSize, style: RoundedCornerStyle = .continuous)
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum ShapeType: Equatable {
     case rounded(RoundedType)
     case rectangle
@@ -15,11 +18,13 @@ public enum ShapeType: Equatable {
 }
 
 // sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol ShapeInteractable: AnyObject {
     var presenter: ShapePresenter { get }
     var type: CurrentValueSubject<ShapeType, Never> { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class ShapeInteractor: ShapeInteractable {
     let presenter = ShapePresenter()
     let type: CurrentValueSubject<ShapeType, Never>
@@ -31,3 +36,5 @@ final class ShapeInteractor: ShapeInteractable {
         type.assign(to: \.type, on: presenter).store(in: &cancellables)
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Shape/ShapeInteractor.swift
+++ b/Sources/SkeletonUI/Shape/ShapeInteractor.swift
@@ -1,5 +1,6 @@
 #if arch(x86_64) || arch(arm64)
 
+import Combine
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)

--- a/Sources/SkeletonUI/Shape/ShapePresenter.swift
+++ b/Sources/SkeletonUI/Shape/ShapePresenter.swift
@@ -1,5 +1,10 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class ShapePresenter: ObservableObject {
     @Published var type: ShapeType = .capsule
 }
+
+#endif

--- a/Sources/SkeletonUI/Skeleton/SkeletonForEach.swift
+++ b/Sources/SkeletonUI/Skeleton/SkeletonForEach.swift
@@ -1,3 +1,5 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -18,3 +20,5 @@ public struct SkeletonForEach<Data, Content>: View where Data: RandomAccessColle
         }
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Skeleton/SkeletonInteractor.swift
+++ b/Sources/SkeletonUI/Skeleton/SkeletonInteractor.swift
@@ -1,7 +1,9 @@
+#if arch(x86_64) || arch(arm64)
+
 import Combine
 import SwiftUI
 
-// sourcery: AutoMockable
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 protocol SkeletonInteractable: AnyObject {
     var presenter: SkeletonPresenter { get }
     var shape: ShapeInteractable { get }
@@ -10,6 +12,7 @@ protocol SkeletonInteractable: AnyObject {
     var animation: AnimationInteractable { get }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class SkeletonInteractor: SkeletonInteractable {
     let presenter: SkeletonPresenter
     let shape: ShapeInteractable
@@ -25,3 +28,5 @@ final class SkeletonInteractor: SkeletonInteractable {
         self.animation = animation
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Skeleton/SkeletonList.swift
+++ b/Sources/SkeletonUI/Skeleton/SkeletonList.swift
@@ -1,3 +1,5 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -18,3 +20,5 @@ public struct SkeletonList<Data, Content>: View where Data: RandomAccessCollecti
         }
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Skeleton/SkeletonPresenter.swift
+++ b/Sources/SkeletonUI/Skeleton/SkeletonPresenter.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 final class SkeletonPresenter: ObservableObject {
     @Published var loading: Bool
     @Published var size: CGSize?
@@ -13,3 +16,5 @@ final class SkeletonPresenter: ObservableObject {
         self.animated = animated ?? .default
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Skeleton/SkeletonShape.swift
+++ b/Sources/SkeletonUI/Skeleton/SkeletonShape.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 struct SkeletonShape: Shape {
     @ObservedObject private var angle: AnglePresenter
     @ObservedObject private var shape: ShapePresenter
@@ -62,3 +65,5 @@ struct SkeletonShape: Shape {
         }
     }
 }
+
+#endif

--- a/Sources/SkeletonUI/Skeleton/SkeletonView.swift
+++ b/Sources/SkeletonUI/Skeleton/SkeletonView.swift
@@ -1,5 +1,8 @@
+#if arch(x86_64) || arch(arm64)
+
 import SwiftUI
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 struct SkeletonView: View {
     private var shape: ShapePresenter
     private var angle: AnglePresenter
@@ -23,3 +26,5 @@ struct SkeletonView: View {
         SkeletonShape(angle: angle, shape: shape, radius: radius, opacity: opacity, position: position, appearance: appearance)
     }
 }
+
+#endif


### PR DESCRIPTION
### Issue Link :link:
Projects with a minimum target < iOS 13 receive errors when importing this library

### Goals :soccer:
• Enable SkeletonUI to be imported and used by projects with a minimum target that is < iOS 13

### Implementation Details :construction:
• Add available checks
• Add `#if arch(x86_64) || arch(arm64)` checks
