### PR TITLE
#36: Two SkeletonForEach in a LazyVGrid causes duplicate IDs

### DIFF
--- a/Sources/SkeletonUI/Extensions/View+SkeletonModifier.swift
+++ b/Sources/SkeletonUI/Extensions/View+SkeletonModifier.swift
@@ -31,3 +31,13 @@ public extension View {
         .animation(transition.animation, value: loading)
     }
 }
+
+extension View {
+    @ViewBuilder func `if`<T>(_ condition: Bool, transform: (Self) -> T) -> some View where T : View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/SkeletonUI/Skeleton/SkeletonForEach.swift
+++ b/Sources/SkeletonUI/Skeleton/SkeletonForEach.swift
@@ -15,6 +15,7 @@ public struct SkeletonForEach<Data, Content>: View where Data: RandomAccessColle
     public var body: some View {
         ForEach(0 ..< (data.isEmpty ? quantity : data.count), id: \.self) { index in
             self.content(self.data.isEmpty, self.data.isEmpty ? nil : self.data.map { $0 }[index])
+                .if(self.data.isEmpty) { $0.id(UUID()) }
         }
     }
 }


### PR DESCRIPTION
### Issue Link :link:
https://github.com/CSolanaM/SkeletonUI/issues/36

### Goals :soccer:
Enabled `LazyVGrid` to contain multiple `SkeletonForEach` with loading state

### Implementation Details :construction:
* Introduced new extension for View that allows to transform a view only when a condition is true
* Set a random `id` for a skeleton view in `SkeletonForEach` to make sure there is no 2 or more skeleton views with the same `id`

### Testing Details :mag:
No new tests added
