### PR TITLE
Fixed Xcode warning re conformance to Sendable protocol

### DIFF
--- a/Sources/SkeletonUI/Enumerations/ShapeType.swift
+++ b/Sources/SkeletonUI/Enumerations/ShapeType.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
-public enum RoundedType: Equatable {
+public enum RoundedType: Equatable, Sendable {
     case radius(CGFloat, style: RoundedCornerStyle = .continuous)
     case size(CGSize, style: RoundedCornerStyle = .continuous)
 }
 
-public enum ShapeType: Equatable {
+public enum ShapeType: Equatable, Sendable {
     case rounded(RoundedType)
     case rectangle
     case circle


### PR DESCRIPTION
### Goals :soccer:
Fix Xcode 15.4 warning:
> Warning: Stored property 'shape' of 'Sendable'-conforming struct 'SkeletonShape' has non-sendable type 'ShapeType'

### Implementation Details :construction:
`RoundedType` and `ShapeType` already satisfy the requirements of Sendable protocol, but must be declared explicitly because those enums are `public`.

https://developer.apple.com/documentation/swift/sendable

### Testing Details :mag:
Build the package with Xcode 15.4 and observe the warning is gone.
