### PR TITLE
feat: Add parent activated modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,29 @@ struct UsersView: View {
 }
 ```
 
+### Parent activation:
+
+```swift
+import SkeletonUI
+import SwiftUI
+
+struct UsersView: View {
+    @State var loading = true
+    let user: User
+
+    var body: some View {
+        VStack {
+            Text(user.name)
+                .skeleton()
+
+            Text(user.email)
+                .skeleton(with: false)
+        }
+        .skeletonActive(loading)
+    }
+}
+```
+
 # Change Log :calendar:
 
 See [CHANGELOG.md](https://github.com/CSolanaM/SkeletonUI/blob/master/CHANGELOG.md) for details.

--- a/Sources/SkeletonUI/Extensions/View+SkeletonModifier.swift
+++ b/Sources/SkeletonUI/Extensions/View+SkeletonModifier.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension View {
-    func skeleton(with loading: Bool,
+    func skeleton(with loading: Bool? = .none,
                   size: CGSize? = .none,
                   transition: (type: AnyTransition, animation: Animation?) = (.opacity, .default),
                   animation: AnimationType = .linear(),
@@ -11,12 +11,61 @@ public extension View {
                   lines: Int = 1,
                   scales: [Int: CGFloat]? = .none,
                   spacing: CGFloat? = .none) -> some View {
+        SkeletonView(content: self,
+                     loading: loading,
+                     size: size,
+                     transition: transition,
+                     animation: animation,
+                     appearance: appearance,
+                     shape: shape,
+                     lines: lines,
+                     scales: scales,
+                     spacing: spacing)
+    }
+  
+  func skeletonActive(_ loading: Bool) -> some View {
+      environment(\.skeletonActive, loading)
+  }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+private struct SkeletonActiveKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+private extension EnvironmentValues {
+    var skeletonActive: Bool {
+        get { self[SkeletonActiveKey.self] }
+        set { self[SkeletonActiveKey.self] = newValue }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+private struct SkeletonView<Content: View>: View {
+    @Environment(\.skeletonActive) private var skeletonActive
+
+    let content: Content
+    let loading: Bool?
+    let size: CGSize?
+    let transition: (type: AnyTransition, animation: Animation?)
+    let animation: AnimationType
+    let appearance: AppearanceType
+    let shape: ShapeType
+    let lines: Int
+    let scales: [Int: CGFloat]?
+    let spacing: CGFloat?
+
+    var body: some View {
+        let isLoading = loading ?? skeletonActive
+
         ZStack {
-            if loading {
+            if isLoading {
                 VStack(spacing: spacing) {
                     ForEach(.zero ..< lines, id: \.self) { line in
                         GeometryReader { geometry in
-                            modifier(SkeletonModifier(shape: shape, animation: animation, appearance: appearance))
+                            content
+                                .modifier(SkeletonModifier(shape: shape, animation: animation, appearance: appearance))
                                 .frame(width: (scales?[line] ?? 1) * geometry.size.width, height: geometry.size.height)
                         }
                     }
@@ -24,10 +73,10 @@ public extension View {
                 .frame(width: size?.width, height: size?.height)
                 .transition(transition.type)
             } else {
-                self
+                content
                     .transition(transition.type)
             }
         }
-        .animation(transition.animation, value: loading)
+        .animation(transition.animation, value: isLoading)
     }
 }


### PR DESCRIPTION
### Goals :soccer:
- Add parent-level skeleton activation.
- Allow child views to call `.skeleton()` without passing `with`.
- Keep explicit child loading state as an override when `.skeleton(with:)` is provided.

### Implementation Details :construction:
- Added `.skeletonActive(_:)` as a parent view modifier using SwiftUI environment.
- Updated `.skeleton(with:)` so `with` is optional and defaults to `nil`.
- When `with` is `nil`, skeleton state is resolved from the parent environment.
- When `with` is `true` or `false`, the child uses that explicit value instead of parent state.

### Testing Details :mag:
- Ran `swift test --filter UnitTests` successfully.